### PR TITLE
update img to github raw file so public pypi can load it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   
-# <img src="docs/_static/logo.png" width="150px"> Squirrel Core
+# <img src="https://raw.githubusercontent.com/merantix-momentum/squirrel-core/main/docs/_static/logo.png" width="150px"> Squirrel Core
   
 **Share, load, and transform data in a collaborative, flexible, and efficient way**
 


### PR DESCRIPTION
# Description

update image address to github raw file so public pypi page can load it. 
Current, the page have the image empty https://pypi.org/project/squirrel-core/ 

Fixes # issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
