### PR TITLE
fix readthedoc

### DIFF
--- a/requirements.doc.in
+++ b/requirements.doc.in
@@ -5,3 +5,4 @@ Sphinx<4.0.0
 sphinx_versions
 sphinx_rtd_theme
 sphinx-autoapi
+Jinja2<3.1 # breaks readthedoc for newer version

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,3 @@ random-name
 ruamel.yaml
 tqdm
 numba
-typing-extensions<4,>=3.7.0 # required by apache-beam 2.35.0

--- a/requirements.in
+++ b/requirements.in
@@ -8,5 +8,4 @@ random-name
 ruamel.yaml
 tqdm
 numba
-# typing-extensions<4,>=3.7.0 # required by apache-beam 2.35.0
-# TODO resolution failure. Add this back once we have a functional main.
+typing-extensions<4,>=3.7.0 # required by apache-beam 2.35.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -364,8 +364,8 @@ tqdm==4.64.0 \
     --hash=sha256:74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6
 twine==4.0.0 \
     --hash=sha256:6f7496cf14a3a8903474552d5271c79c71916519edb42554f23f42a8563498a9
-typing-extensions==3.10.0.2 \
-    --hash=sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34
+typing_extensions==4.1.1 \
+    --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
 Unidecode==1.3.4 \
     --hash=sha256:afa04efcdd818a93237574791be9b2817d7077c25a068b00f8cff7baa4e59257
 urllib3==1.26.9 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -137,8 +137,8 @@ itsdangerous==2.1.2 \
     --hash=sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44
 jeepney==0.8.0 \
     --hash=sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755
-Jinja2==3.1.1 \
-    --hash=sha256:539835f51a74a69f41b848a9645dbdc35b4f20a3b601e2d9a7e22947b15ff119
+Jinja2==3.0.3 \
+    --hash=sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8
 jmespath==1.0.0 \
     --hash=sha256:e8dcd576ed616f14ec02eed0005c85973b5890083313860136657e24784e4c04
 keyring==23.5.0 \
@@ -281,8 +281,8 @@ requests-toolbelt==0.9.1 \
     --hash=sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f
 rfc3986==2.0.0 \
     --hash=sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd
-rich==12.1.0 \
-    --hash=sha256:b60ff99f4ff7e3d1d37444dee2b22fdd941c622dbc37841823ec1ce7f058b263
+rich==12.2.0 \
+    --hash=sha256:c50f3d253bc6a9bb9c79d61a26d510d74abdf1b16881260fab5edfc3edfb082f
 rsa==4.8 \
     --hash=sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb
 ruamel.yaml==0.17.21 \
@@ -364,8 +364,8 @@ tqdm==4.64.0 \
     --hash=sha256:74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6
 twine==4.0.0 \
     --hash=sha256:6f7496cf14a3a8903474552d5271c79c71916519edb42554f23f42a8563498a9
-typing_extensions==4.1.1 \
-    --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
+typing-extensions==3.10.0.2 \
+    --hash=sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34
 Unidecode==1.3.4 \
     --hash=sha256:afa04efcdd818a93237574791be9b2817d7077c25a068b00f8cff7baa4e59257
 urllib3==1.26.9 \


### PR DESCRIPTION
# Description

The latest jinja2 release breaks the doc build, this fixes this. 
The rendered doc can be seen from here: https://squirrel-core.readthedocs.io/en/tiansu-fix-readthedoc/ (This is hidden. Let me know your readthedocs account, then I can add you to see it)

Fixes # issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
