### PR TITLE
Revise catalog api

### DIFF
--- a/squirrel/catalog/catalog.py
+++ b/squirrel/catalog/catalog.py
@@ -141,7 +141,7 @@ class Catalog(MutableMapping):
     def join(self, other: Catalog) -> Catalog:
         """Return a joined Catalog out of two disjoint Catalogs."""
         assert len(self.intersection(other)) == 0
-        return self.update(other)
+        return self.union(other)
 
     def difference(self, other: Catalog) -> Catalog:
         """Return a Catalog which consists of the difference of the input Catalogs."""
@@ -155,8 +155,8 @@ class Catalog(MutableMapping):
                     new_cat[iden, source.version] = source
         return new_cat
 
-    def update(self, other: Catalog) -> Catalog:
-        """Update the catalog with the sources from other, overwriting existing sources."""
+    def union(self, other: Catalog) -> Catalog:
+        """Return a catalog with combined sources. If there is an intersection, sources from `other` will be kept."""
         cat = self.copy()
         oth_cat = other.copy()
 

--- a/squirrel/catalog/catalog.py
+++ b/squirrel/catalog/catalog.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import json
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -14,6 +13,7 @@ from typing import (
     MutableMapping,
     NamedTuple,
     Optional,
+    TYPE_CHECKING,
     Tuple,
     Type,
     Union,

--- a/squirrel/catalog/catalog.py
+++ b/squirrel/catalog/catalog.py
@@ -81,8 +81,8 @@ class Catalog(MutableMapping):
         else:
             identifier, version = identifier
             del self._sources[identifier][version]
-            if (self._sources[identifier]) == 0:
-                del self.sources[identifier]
+            if len(self._sources[identifier]) == 0:
+                del self._sources[identifier]
 
     def __setitem__(self, identifier: Union[str, CatalogKey, Tuple[str, int]], value: Source) -> None:  # noqa D105
         if isinstance(identifier, str):
@@ -172,9 +172,9 @@ class Catalog(MutableMapping):
         new_cat = Catalog()
         for iden, source in cat.items():
             ver = source.version
-            if iden in oth_cat and ver in oth_cat.sources[iden]:
-                assert cat[iden, ver] == oth_cat[iden, ver]
-                new_cat[iden, ver] = source
+            if (key := (iden, ver)) in oth_cat:
+                assert cat[key] == oth_cat[key]
+                new_cat[key] = source
         return new_cat
 
     def filter(self: Catalog, predicate: Callable[[CatalogSource], bool]) -> Catalog:

--- a/squirrel/catalog/catalog.py
+++ b/squirrel/catalog/catalog.py
@@ -86,7 +86,7 @@ class Catalog(MutableMapping):
 
     def __setitem__(self, identifier: Union[str, CatalogKey, Tuple[str, int]], value: Source) -> None:  # noqa D105
         if isinstance(identifier, str):
-            version = 1
+            version = 1 if identifier not in self else self._handle_latest(identifier, -1) + 1
         else:
             identifier, version = identifier
         versions = self._sources.setdefault(identifier, {})

--- a/squirrel/catalog/catalog.py
+++ b/squirrel/catalog/catalog.py
@@ -67,14 +67,14 @@ class Catalog(MutableMapping):
         # deep equal
         return all(source == other[src_id, source.version] for src_id, source in self)
 
-    def __contains__(self, identifier: Union[str, CatalogKey]) -> bool:  # noqa D105
+    def __contains__(self, identifier: Union[str, CatalogKey, Tuple[str, int]]) -> bool:  # noqa D105
         if isinstance(identifier, str):
             return identifier in self.sources
 
         identifier, version = identifier
         return identifier in self and version in self.get_versions(identifier)
 
-    def __delitem__(self, identifier: Union[str, CatalogKey]) -> None:  # noqa D105
+    def __delitem__(self, identifier: Union[str, CatalogKey, Tuple[str, int]]) -> None:  # noqa D105
         if isinstance(identifier, str):
             # if not given a specific version, we remove all versions of the identifier
             del self._sources[identifier]
@@ -84,7 +84,7 @@ class Catalog(MutableMapping):
             if (self._sources[identifier]) == 0:
                 del self.sources[identifier]
 
-    def __setitem__(self, identifier: Union[str, CatalogKey], value: Source) -> None:  # noqa D105
+    def __setitem__(self, identifier: Union[str, CatalogKey, Tuple[str, int]], value: Source) -> None:  # noqa D105
         if isinstance(identifier, str):
             version = 1
         else:
@@ -95,7 +95,7 @@ class Catalog(MutableMapping):
     def _handle_latest(self, identifier: str, index: int) -> int:
         return max(self._sources[identifier].keys()) if index == -1 else index
 
-    def __getitem__(self, identifier: Union[str, CatalogKey]) -> CatalogSource:  # noqa D105
+    def __getitem__(self, identifier: Union[str, CatalogKey, Tuple[str, int]]) -> CatalogSource:  # noqa D105
         if isinstance(identifier, str):
             version = -1
         else:

--- a/squirrel/catalog/source.py
+++ b/squirrel/catalog/source.py
@@ -1,6 +1,6 @@
 import json
-from dataclasses import dataclass, field
-from typing import Dict, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Dict
 
 __all__ = ["Source"]
 
@@ -8,9 +8,8 @@ __all__ = ["Source"]
 @dataclass(init=True)
 class Source:
     driver_name: str
-    driver_kwargs: Optional[Dict[str, str]] = field(default_factory=dict)
-    metadata: Optional[Dict[str, str]] = field(default_factory=dict)
+    driver_kwargs: Dict[str, str] = field(default_factory=dict)
+    metadata: Dict[str, str] = field(default_factory=dict)
 
     def __repr__(self) -> str:  # noqa D105
-        dct = {"driver_name": self.driver_name, "driver_kwargs": self.driver_kwargs, "metadata": self.metadata}
-        return json.dumps(dct, indent=2, default=str)
+        return json.dumps(asdict(self), indent=2, default=str)

--- a/squirrel/catalog/yaml.py
+++ b/squirrel/catalog/yaml.py
@@ -45,7 +45,8 @@ def catalog2yamlcatalog(catobj: catalog.Catalog) -> YamlCatalog:
             version=source.version,
             metadata=source.metadata,
         )
-        for iden, source in catobj
+        for iden in catobj.keys()
+        for _ver, source in catobj.get_versions(iden).items()
     ]
     return YamlCatalog(sources=sources)
 

--- a/squirrel/catalog/yaml.py
+++ b/squirrel/catalog/yaml.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Dict, List
 
 import ruamel.yaml
 
 from squirrel import __version__ as sq_ver
-from squirrel.catalog import Catalog, CatalogKey, Source
+from squirrel import catalog
 
 __all__ = ["prep_yaml", "catalog2yamlcatalog", "yamlcatalog2catalog"]
 
@@ -14,7 +16,7 @@ def prep_yaml() -> ruamel.yaml.YAML:
     yaml = ruamel.yaml.YAML()
     yaml.register_class(YamlSource)
     yaml.register_class(YamlCatalog)
-    yaml.register_class(CatalogKey)
+    yaml.register_class(catalog.CatalogKey)
     return yaml
 
 
@@ -33,25 +35,22 @@ class YamlCatalog:
     sources: List[YamlSource] = field(default_factory=list)
 
 
-def catalog2yamlcatalog(catobj: Catalog) -> YamlCatalog:
+def catalog2yamlcatalog(catobj: catalog.Catalog) -> YamlCatalog:
     """Convert a Catalog into a serializable catalog DTO"""
-    sources = []
-    # flatten version graph
-    for k, s in catobj.sources.items():
-        for sv in s.versions.values():
-            sources.append(
-                YamlSource(
-                    identifier=k,
-                    driver_name=sv.driver_name,
-                    driver_kwargs=sv.driver_kwargs,
-                    version=sv.version,
-                    metadata=sv.metadata,
-                )
-            )
+    sources = [
+        YamlSource(
+            identifier=iden,
+            driver_name=source.driver_name,
+            driver_kwargs=source.driver_kwargs,
+            version=source.version,
+            metadata=source.metadata,
+        )
+        for iden, source in catobj
+    ]
     return YamlCatalog(sources=sources)
 
 
-def yamlcatalog2catalog(yamlcat: YamlCatalog) -> Catalog:
+def yamlcatalog2catalog(yamlcat: YamlCatalog) -> catalog.Catalog:
     """Convert a serializable catalog DTO into a Catalog"""
     yamlcat = YamlCatalog(**yamlcat.__dict__)  # recreate to set default values
 
@@ -59,11 +58,11 @@ def yamlcatalog2catalog(yamlcat: YamlCatalog) -> Catalog:
     ver_split = [int(x) for x in yamlcat.version.split(".")]
     assert ver_split[0] > 0 or (ver_split[0] == 0 and ver_split[1] >= 4)
 
-    cat = Catalog()
+    cat = catalog.Catalog()
     for s in yamlcat.sources:
         s_cp = YamlSource(**s.__dict__)  # recreate to set default values
         # flat list to version graph
-        cat[s_cp.identifier][s_cp.version] = Source(
+        cat[s_cp.identifier, s_cp.version] = catalog.Source(
             driver_name=s_cp.driver_name,
             driver_kwargs=dict(**s_cp.driver_kwargs),
             metadata=dict(**s_cp.metadata),

--- a/squirrel/driver/source_combiner.py
+++ b/squirrel/driver/source_combiner.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from dask.dataframe import DataFrame
 
     from squirrel.catalog import Catalog, CatalogKey
-    from squirrel.catalog.source import Source
+    from squirrel.catalog.catalog import CatalogSource
     from squirrel.iterstream import Composable
     from squirrel.store import AbstractStore
 
@@ -39,7 +39,7 @@ class SourceCombiner(MapDriver, DataFrameDriver):
         """Ids of all subsets defined by this source."""
         return list(self._subsets.keys())
 
-    def get_source(self, subset: str) -> Source:
+    def get_source(self, subset: str) -> CatalogSource:
         """Returns subset source based on subset id.
 
         Args:
@@ -49,7 +49,7 @@ class SourceCombiner(MapDriver, DataFrameDriver):
             (Source): Subset source.
         """
         key, version = self._subsets[subset]
-        return self._catalog[key][version]
+        return self._catalog[key, version]
 
     def get_iter(self, subset: Optional[str] = None, **kwargs) -> Composable:
         """Routes to the :py:meth:`get_iter` method of the appropriate subset driver.

--- a/test/test_catalog/test_catalog.py
+++ b/test/test_catalog/test_catalog.py
@@ -67,7 +67,7 @@ def test_catalog_setapi() -> None:
     assert len(intersection) == 2
     assert len(intersection.get_versions("s1")) == 1
 
-    union = cat1.update(cat2)
+    union = cat1.union(cat2)
     assert "s0" in union
     assert "s1" in union
     assert "s2" in union

--- a/test/test_catalog/test_catalog.py
+++ b/test/test_catalog/test_catalog.py
@@ -1,6 +1,6 @@
 import pytest
 
-from squirrel.catalog import Catalog, Source
+from squirrel.catalog import Catalog, CatalogKey, Source
 from squirrel.constants import URL
 from squirrel.driver import Driver
 from squirrel.framework.plugins.plugin_manager import register_driver, register_source
@@ -58,7 +58,7 @@ def test_catalog_setapi() -> None:
     cat2 = Catalog()
     cat2["s0"] = Source("csv", driver_kwargs={"path": "./test0.csv"})
     cat2["s1", 1] = Source("csv", driver_kwargs={"path": "./test1.csv"})
-    cat2["s1", 2] = Source("csv", driver_kwargs={"path": "./test1_v2.csv"})
+    cat2[CatalogKey("s1", 2)] = Source("csv", driver_kwargs={"path": "./test1_v2.csv"})
     cat2["s3"] = Source("csv", driver_kwargs={"path": "./test3.csv"})
 
     intersection = cat1.intersection(cat2)

--- a/test/test_driver/test_sourcecombiner.py
+++ b/test/test_driver/test_sourcecombiner.py
@@ -7,9 +7,9 @@ def test_combiner_in_catalog(test_path: URL) -> None:
     """Test if sources can be combined into a source combiner"""
     c = Catalog()
 
-    c["train"] = Source("file", driver_kwargs={"path": test_path + "train.dummy"})
-    c["val"] = Source("file", driver_kwargs={"path": test_path + "val.dummy"})
-    c["test"] = Source("file", driver_kwargs={"path": test_path + "test.dummy"})
+    c["train"] = Source("file", driver_kwargs={"path": f"{test_path}train.dummy"})
+    c["val"] = Source("file", driver_kwargs={"path": f"{test_path}val.dummy"})
+    c["test"] = Source("file", driver_kwargs={"path": f"{test_path}test.dummy"})
 
     c["combined"] = Source(
         "source_combiner",
@@ -24,15 +24,15 @@ def test_combiner_in_catalog(test_path: URL) -> None:
 
     d = c["combined"].get_driver()
     assert len(d.subsets) == 3
-    assert d.get_source("subset1").get_driver().path == test_path + "train.dummy"
-    assert d.get_source("subset2").get_driver().path == test_path + "val.dummy"
-    assert d.get_source("subset3").get_driver().path == test_path + "test.dummy"
+    assert d.get_source("subset1").get_driver().path == f"{test_path}train.dummy"
+    assert d.get_source("subset2").get_driver().path == f"{test_path}val.dummy"
+    assert d.get_source("subset3").get_driver().path == f"{test_path}test.dummy"
 
 
 def test_copy_combiner(test_path: URL) -> None:
     """Test if source combiner can be serialized"""
     c = Catalog()
-    c["train"] = Source("file", driver_kwargs={"path": test_path + "train.dummy"})
+    c["train"] = Source("file", driver_kwargs={"path": f"{test_path}train.dummy"})
     c["combined"] = Source(
         "source_combiner",
         driver_kwargs={


### PR DESCRIPTION
# Description

The primary purpose of the PR is to enable using CatalogKeys when accessing/setting data sources in the catalog.
Along the way, I figured the code is a bit easier to follow when the versioning of the source is handled by the Catalog instead of the CatalogSource.

Since we can set a new version using the CatalogKey now, the DummyCatalogSource is not needed and the user should never try to set the version of a source directly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/usage/code_of_conduct.html) (external contributors only)
- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
