### PR TITLE
fix SourceCombiner.get_iter() not interleaving correctly

### DIFF
--- a/squirrel/driver/source_combiner.py
+++ b/squirrel/driver/source_combiner.py
@@ -64,7 +64,7 @@ class SourceCombiner(MapDriver, DataFrameDriver):
         """
         if subset is None:
             return IterableSource(
-                more_itertools.interleave_longest(self.get_iter(subset=k, **kwargs) for k in self.subsets)
+                more_itertools.interleave_longest(*[self.get_iter(subset=k, **kwargs) for k in self.subsets])
             )
         return self.get_source(subset).get_driver().get_iter(**kwargs)
 

--- a/test/test_driver/test_sourcecombiner.py
+++ b/test/test_driver/test_sourcecombiner.py
@@ -1,6 +1,5 @@
 from tempfile import TemporaryDirectory
 
-import numpy as np
 import pandas as pd
 
 from squirrel.catalog import Catalog, CatalogKey

--- a/test/test_driver/test_sourcecombiner.py
+++ b/test/test_driver/test_sourcecombiner.py
@@ -1,15 +1,23 @@
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import pandas as pd
+
 from squirrel.catalog import Catalog, CatalogKey
 from squirrel.catalog.source import Source
 from squirrel.constants import URL
 
 
-def test_combiner_in_catalog(test_path: URL) -> None:
+def test_combiner_in_catalog() -> None:
     """Test if sources can be combined into a source combiner"""
     c = Catalog()
+    tmpdir = TemporaryDirectory()
 
-    c["train"] = Source("file", driver_kwargs={"path": test_path + "train.dummy"})
-    c["val"] = Source("file", driver_kwargs={"path": test_path + "val.dummy"})
-    c["test"] = Source("file", driver_kwargs={"path": test_path + "test.dummy"})
+    for split in ("train", "val", "test"):
+        fname = f"{tmpdir.name}/{split}.csv"
+        data = pd.DataFrame(dict(split=[split]))  # one row, one col df, only value of "split" changes
+        data.to_csv(fname)
+        c[split] = Source("csv", driver_kwargs={"path": fname})
 
     c["combined"] = Source(
         "source_combiner",
@@ -24,9 +32,11 @@ def test_combiner_in_catalog(test_path: URL) -> None:
 
     d = c["combined"].get_driver()
     assert len(d.subsets) == 3
-    assert d.get_source("subset1").get_driver().path == test_path + "train.dummy"
-    assert d.get_source("subset2").get_driver().path == test_path + "val.dummy"
-    assert d.get_source("subset3").get_driver().path == test_path + "test.dummy"
+    assert d.get_source("subset1").get_driver().path == f"{tmpdir.name}/train.csv"
+    assert d.get_source("subset2").get_driver().path == f"{tmpdir.name}/val.csv"
+    assert d.get_source("subset3").get_driver().path == f"{tmpdir.name}/test.csv"
+    all_rows = d.get_iter().collect()
+    assert [r.split for r in all_rows] == ["train", "val", "test"]
 
 
 def test_copy_combiner(test_path: URL) -> None:


### PR DESCRIPTION
# Description

`SourceCombiner.get_iter()` should interleave the iterables of all its sources. Currently, we feed `more_itertools.interleave_longest` a single generator object rather than each iterable as a separate arg. This requires an additional `flatten()` call to get the individual samples through `SourceCombiner.get_iter()`.

The PR fixes this issue by unpacking a list of iterables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/usage/code_of_conduct.html) (external contributors only)
- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All dependency changes have been reflected in the pip requirement files. 
