### PR TITLE
Update fs.open mode for catalog

### DIFF
--- a/squirrel/catalog/catalog.py
+++ b/squirrel/catalog/catalog.py
@@ -201,7 +201,7 @@ class Catalog(MutableMapping):
         cat = Catalog()
         for file in paths:
             fs = get_fs_from_url(file)
-            with fs.open(file) as fh:
+            with fs.open(file, mode="rb") as fh:
                 new_cat = Catalog.from_str(fh.read())
                 cat = cat.join(new_cat)
         return cat
@@ -220,7 +220,7 @@ class Catalog(MutableMapping):
 
         yaml = prep_yaml()
         fs = get_fs_from_url(path)
-        with fs.open(path, mode="w+") as fh:
+        with fs.open(path, mode="wb") as fh:
             ser = catalog2yamlcatalog(self)
             yaml.dump(ser, fh)
 


### PR DESCRIPTION
# Description

Currently `w+` fails when trying to write to blob storage. It also gives more right than seem to be needed for `to_file`.
Making the mode explicit also for `from_file` is not changing anything, but making this explicit in case the fsspec default changes in the future.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ x ] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/usage/code_of_conduct.html) (external contributors only)
- [ x ] Lint and unit tests pass locally with my changes
- [ x ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
