### PR TITLE
zip multiple iterables as a source

### DIFF
--- a/squirrel/iterstream/source.py
+++ b/squirrel/iterstream/source.py
@@ -139,3 +139,12 @@ class IterableSamplerSource(Composable):
                     self.probs = [p / s for p in probs]
             if len(self.iterators) == 0:
                 break
+
+
+class IterableZipSource(Composable):
+
+    def __init__(self, iterables: t.List[t.Iterable]):
+        super().__init__(source=iterables)
+
+    def __iter__(self):
+        yield from zip(*self.source)

--- a/squirrel/iterstream/source.py
+++ b/squirrel/iterstream/source.py
@@ -142,6 +142,7 @@ class IterableSamplerSource(Composable):
 
 
 class IterableZipSource(Composable):
+    """Makes it possible to zip items from several iterables and use it as a source."""
 
     def __init__(self, iterables: t.List[t.Iterable]):
         super().__init__(source=iterables)


### PR DESCRIPTION
# Description

The use case: we have a store with samples, and `1..n` other stores that each contain only features. These stores must have the same keys and same number of samples per shard.  

`IterableZipSource` makes it possible to zip items from several iterables and use that as a source. For instance:

```
it1 = MessagepackDriver(url1).get_iter()
it2 = MessagepackDriver(url2).get_iter()

it3 = IterableZipSource(iterables=[it1, it2]).collect()

```

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/usage/code_of_conduct.html) (external contributors only)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
