### PR TITLE
Nvidia DALI external source integration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,7 @@
 testpaths =
     test
     squirrel/integration_test
-addopts = -p no:warnings -v
+# ignore dali tests for now because we need CUDA + DALI installed and a GPU for 
+# these tests to run, but currently our testing image is CPU-only
+addopts = -p no:warnings -v --ignore=test/test_iterstream/test_dali_composables.py
 norecursedirs = '.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg'

--- a/squirrel/iterstream/base.py
+++ b/squirrel/iterstream/base.py
@@ -257,8 +257,10 @@ class Composable:
         return self.compose(iterstream.torch_composables.TorchIterable)
 
     def to_dali_external_source(self, batch_size: int, collation_fn: t.Callable[[t.List], t.List]) -> Composable:
-        """Convert the stream to a Nvidia DALI external source that is directly usable by nvidia.dali.fn.external_source
-        in a DALI pipeline."""
+        """
+        Convert the stream to a Nvidia DALI external source that is directly usable by nvidia.dali.fn.external_source
+        in a DALI pipeline.
+        """
         return self.compose(iterstream.dali_composables.DaliExternalSource, batch_size, collation_fn)
 
 

--- a/squirrel/iterstream/base.py
+++ b/squirrel/iterstream/base.py
@@ -256,6 +256,11 @@ class Composable:
         """Convert the stream to a torch iterable."""
         return self.compose(iterstream.torch_composables.TorchIterable)
 
+    def to_dali_external_source(self, batch_size: int, collation_fn: t.Callable[[t.List], t.List]) -> Composable:
+        """Convert the stream to a Nvidia DALI external source that is directly usable by nvidia.dali.fn.external_source
+        in a DALI pipeline."""
+        return self.compose(iterstream.dali_composables.DaliExternalSource, batch_size, collation_fn)
+
 
 class _Iterable(Composable):
     """

--- a/squirrel/iterstream/dali_composables.py
+++ b/squirrel/iterstream/dali_composables.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Callable, Dict, List
+
+import numpy as np
+from squirrel.iterstream import Composable
+
+
+def default_dict_collate(records: List[Dict[str, Any]]) -> List[np.ndarray]:
+    """Converts a batch of a list of dicts to a list of numpy arrays. This converts your data from e.g.
+        [{"img": [...], "label": 0}, {"img": [...], "label": 1}, ...] into
+        [np.array(np.array([...]), np.array([...])), np.array([np.array(0),np.array(1)])].
+
+        Leaving this here, because this function is useful for turning Squirrel pipelines that fetch dicts
+        into a Nvidia DALI external source that accepts a list of numpy arrays.
+
+    Args:
+        records (List[Dict[str, Any]]): A batch to convert.
+
+    Returns:
+        List[np.ndarray]: Re-formatted batch of numpy arrays.
+    """
+    batch = defaultdict(list)
+    for elem in records:
+        for k, v in elem.items():
+            batch[k].append(np.array(v))
+    return [np.array(v) for v in batch.values()]
+
+
+class DaliExternalSource(Composable):
+    """Mixin-Composable to turn the Squirrel iterator into a DALI external source."""
+
+    def __init__(self, batch_size: int, collation_fn: Callable[[List], List]) -> None:
+        """Initializes the DaliExternalSource.
+
+        Args:
+            batch_size (int): The number of items in your batch.
+            collation_fn (Callable[[Any], List]): The collation function to batch a list of items.
+                DALI expects your data as a list of numpy or cupy arrays.
+        """
+        super().__init__()
+        self.collation_fn = collation_fn
+        self.batch_size = batch_size
+
+    def __iter__(self) -> DaliExternalSource:
+        """Returns the DaliExternalSource. Also initializes the iterator.
+
+        Returns:
+            DaliExternalSource: The iterator object.
+        """
+        self.it = iter(
+            self.source.batched(
+                self.batch_size,
+                collation_fn=self.collation_fn,
+                drop_last_if_not_full=False,
+            )
+        )
+        return self
+
+    def __next__(self) -> List[np.ndarray]:
+        """Returns the next item of the iterator.
+
+        Returns:
+            List[np.ndarray]: The next batch of your dataset.
+        """
+        return next(self.it)

--- a/test/test_iterstream/test_dali_composables.py
+++ b/test/test_iterstream/test_dali_composables.py
@@ -52,12 +52,28 @@ def pipeline(it: DaliExternalSource, device: str) -> Tuple[DataNode]:
 def get_classification_dali_it(
     it: DaliExternalSource, device: str, device_id: Optional[int] = None
 ) -> DALIGenericIterator:
+    """Returns DALI generic pytorch iterator over a custom img classification pipeline.
+
+    Args:
+        it (DaliExternalSource): The source passed to DALI fn.external_source.
+        device (str): Which device to put data on.
+        device_id (Optional[int], optional): ID of device. Defaults to None.
+
+    Returns:
+        DALIGenericIterator: DALI generic pytorch iterator.
+    """
     pipe = pipeline(it, device, batch_size=BATCH_SIZE, num_threads=NUM_THREADS, device_id=device_id)
     pipe.build()
     return DALIGenericIterator([pipe], [DATA_KEY, LABEL_KEY])
 
 
-def check_dali_iterator(dali_iter: DALIGenericIterator, device: str):
+def check_dali_iterator(dali_iter: DALIGenericIterator, device: str) -> None:
+    """Runs over the DALI pytorch iterator and checks dataset format.
+
+    Args:
+        dali_iter (DALIGenericIterator): DALI pytorch iterator.
+        device (str): Which device (e.g. "cuda:0") the data is on.
+    """
     counter = 0
     for item in dali_iter:
         # access data of first pipeline

--- a/test/test_iterstream/test_dali_composables.py
+++ b/test/test_iterstream/test_dali_composables.py
@@ -1,0 +1,111 @@
+from typing import List, Optional, Tuple
+
+import numpy as np
+import nvidia.dali.fn as fn
+import pytest
+import torch
+from nvidia.dali import pipeline_def
+from nvidia.dali.pipeline import DataNode
+from nvidia.dali.plugin.pytorch import DALIGenericIterator
+from squirrel.iterstream.dali_composables import (
+    DaliExternalSource,
+    default_dict_collate,
+)
+from squirrel.iterstream.source import IterableSource
+
+NUM_SAMPLES = 1000
+BATCH_SIZE = 16
+NUM_THREADS = 2
+DATA_KEY = "img"
+LABEL_KEY = "label"
+DATA_DIM = (100, 100, 3)
+DATA_RANGE = (0, 255)
+LABEL_RANGE = (0, 1)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def samples() -> List[int]:
+    """Fixture for this module's test data"""
+    data = []
+    for _ in range(NUM_SAMPLES):
+        data.append(
+            {
+                DATA_KEY: np.random.randint(*DATA_RANGE, size=DATA_DIM),
+                LABEL_KEY: np.random.randint(*LABEL_RANGE),
+            }
+        )
+    return data
+
+
+@pipeline_def
+def pipeline(it: DaliExternalSource, device: str) -> Tuple[DataNode]:
+    """A dummy DALI classification pipeline defining the data processing graph.
+
+    Returns:
+        Tuple[DataNode]: The outputs of the operators.
+    """
+    img, label = fn.external_source(source=it, num_outputs=2, device=device)
+    enhanced = fn.brightness_contrast(img, contrast=2)
+    return enhanced, label
+
+
+def get_classification_dali_it(
+    it: DaliExternalSource, device: str, device_id: Optional[int] = None
+) -> DALIGenericIterator:
+    pipe = pipeline(it, device, batch_size=BATCH_SIZE, num_threads=NUM_THREADS, device_id=device_id)
+    pipe.build()
+    return DALIGenericIterator([pipe], [DATA_KEY, LABEL_KEY])
+
+
+def check_dali_iterator(dali_iter: DALIGenericIterator, device: str):
+    counter = 0
+    for item in dali_iter:
+        # access data of first pipeline
+        data = item[0]
+        counter += data[DATA_KEY].shape[0]
+        effective_batch_size = data[LABEL_KEY].shape[0]
+        # check format and if on correct device
+        assert type(data) == dict
+        assert type(data[DATA_KEY]) == torch.Tensor
+        assert data[DATA_KEY].shape[1:] == DATA_DIM
+        assert data[DATA_KEY].device == torch.device(device)
+        assert effective_batch_size == BATCH_SIZE or effective_batch_size == NUM_SAMPLES % BATCH_SIZE
+    assert counter == NUM_SAMPLES
+
+
+def test_dali_external_source_gpu(samples: List[int]) -> None:
+    """Test for DaliExternalSource composable on gpu"""
+    it = IterableSource(samples).compose(DaliExternalSource, BATCH_SIZE, default_dict_collate)
+    dali_iter = get_classification_dali_it(it, device="gpu", device_id=0)
+    check_dali_iterator(dali_iter, "cuda:0")
+
+
+def test_to_dali_external_source_gpu(samples: List[int]) -> None:
+    """Test for to_dali_external_source composable on gpu"""
+    it = IterableSource(samples).to_dali_external_source(BATCH_SIZE, default_dict_collate)
+    dali_iter = get_classification_dali_it(it, device="gpu", device_id=0)
+    check_dali_iterator(dali_iter, "cuda:0")
+
+
+def test_to_dali_external_source_cpu(samples: List[int]) -> None:
+    """Test for to_dali_external_source composable on cpu"""
+    it = IterableSource(samples).to_dali_external_source(BATCH_SIZE, default_dict_collate)
+    dali_iter = get_classification_dali_it(it, device="cpu")
+    check_dali_iterator(dali_iter, "cpu")
+
+
+def test_to_dali_external_source_gpu_multi_epoch(samples: List[int]) -> None:
+    """Test for to_dali_external_source composable on cpu and multi-epoch loading"""
+    it = IterableSource(samples).to_dali_external_source(BATCH_SIZE, default_dict_collate)
+    dali_iter = get_classification_dali_it(it, device="gpu", device_id=0)
+
+    num_epochs = 10
+    counter = 0
+    for _ in range(num_epochs):
+        # iterable needs to be re-created explicitly
+        dali_iter = get_classification_dali_it(it, device="gpu", device_id=0)
+        for item in dali_iter:
+            data = item[0]  # first pipeline
+            counter += data[DATA_KEY].shape[0]
+
+    assert counter == num_epochs * NUM_SAMPLES


### PR DESCRIPTION
# Description

**Motivation**
Squirrel is a fast data loading framework, and Nvidia DALI is a fast, gpu-accelerated library for complex ML workloads such as run-time augmentations. The aim is to provide users with an intuitive interface to use Squirrel as a backend for Nvidia DALI. 

**Context**
For more context, check out these internal benchmarks below. Running the Squirrel pipeline without any augmentations is approx. 33k samples / sec. If you use Squirrel as an external source and an affine image augmentation from DALI you can reach approx. 28k samples / sec. This suggests that DALI can make use full use of Squirrel's speed as the data loading speed is almost not slowed down by the run-time augmentations (33k vs 28k). DALI brings two things to the table: you can augment data in batches and not one-by-one as is necessary with the other frameworks, and you can do it on the GPU. 

<img width="977" alt="Screen Shot 2022-08-03 at 15 36 30" src="https://user-images.githubusercontent.com/50868646/182621557-92e17458-92eb-48bd-b85e-2232352b652b.png">

**Code Design**
- DALI comes with a concept called "pipeline" ([docs](https://docs.nvidia.com/deeplearning/dali/main-user-guide/docs/pipeline.html)), that defines how data should be read and transformed by DALI.  
- We use the `external_source` data reader API in the DALI pipeline, which we can provide with a modified Squirrel Iterable, the `squirrel.iterstream.DaliExternalSource`. 
- As suggested by Nvidia DALI staff, I benchmarked loading the samples one-by-one and let DALI do the batching. It turned out that batching in Squirrel was much faster (18.2k sps vs 32.2 sps). This suggests that DALI profits from the async loading in Squirrel here. 
- As suggested by Nvidia DALI staff, I tried using [parallel external source](https://docs.nvidia.com/deeplearning/dali/user-guide/docs/examples/general/data_loading/parallel_external_source.html?highlight=parallel%20source), which is multi-proc dataloading by DALI. As stated in their docs, DALI prefers single samples (un-batched) here to let DALI handle the multi-proc logic of parallel data fetching. The problem here is that DALI would like a `Callable` external source here, `Iterables` are not allowed for parallel fetching. While this is technically possible (e.g. fit your dataset in one shard and then access the items by their keys, i.e. shard names), indexability is not straightforward and not yet integrated in squirrel. Since DALI already nearly makes use of Squirrel's full performance, we don't see that DALI could speed things up here. But it's worth investigating once the feature is implemented in Squirrel. 
- There was no performance increase by returning `cupy` arrays on the GPU to the `external_source` reader. Numpy was slightly faster, so users are advised to return numpy arrays in their collation function.

**Usage Pattern**
- users will simply turn their iterable into an external source with the iterstream API. 
```python
# define a dummy pipeline
@pipeline_def 
def pipeline(it: DaliExternalSource, device: str) -> Tuple[DataNode]:
    img, label = fn.external_source(source=it, num_outputs=2, device=device)
    enhanced = fn.brightness_contrast(img, contrast=2) # do other augmentations here
    return enhanced, label
    
it = squirrel_iterator.to_dali_external_source(batch_size, my_collation_fn)
pipe = pipeline(it, device, batch_size=BATCH_SIZE)
pipe.build()

loader = DALIGenericIterator([pipe], ["img", "label"])
for item in loader: 
    # ... 
```

**Things to Discuss**
1. I tried turning the iterstream into a `DALIGenericIterator` directly and abstract the above code away, but in my mind that does not make a lot of sense, as DALI users are used to the above API and we are really just an external source. The user will need to define their custom pipeline anyway for their use-case, so I don't see a big benefit of abstracting the below code away into a squirrel functionality - possibly adding some assumptions here and there and thereby limiting the original functionality of DALI (wdyt @AlirezaSohofi ?). 
2. We would need to find out if the `self.i` and `self.n` parameters need to be set for the external source as indicated [here](https://docs.nvidia.com/deeplearning/dali/user-guide/docs/examples/general/data_loading/external_input.html). For now, it seems to work out of the box, but maybe for more complex use-cases these variables are needed for DALI to keep track of the loaded samples. Sidenote: Currently `DaliExternalSource` could also simply be replaced with `squirrel_iterable.batched(bs, fn)`, but I assume that `self.i` and `self.n` are needed somehow (input from NVIDIA needed here), so it's useful to have `DaliExternalSource` where we can add more features.
3. Please check out the `test_to_dali_external_source_gpu_multi_epoch`. After iterating over Squirrel's generator once the iterable is empty. Hence after each epoch we need to create a new `DALIGenericIterator`. Afaik this is also how e.g. Pytorch Lightning handles it. Let me know if that sounds ok, or if we need to loop over the data. 
4. Tests & Requirements: Note that I added pytests for the code, but did not update the requirements accordingly, because the CI currently doesn't run GPU tasks. Moreover, we won't ask users to install DALI for now (also, there are many different versions for different cuda drivers), so we assume people will prefer installing themselves. The `DaliExternalSource` doesn't depend on any DALI code, so the DALI install is technically not required.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/usage/code_of_conduct.html) (external contributors only)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
