### PR TITLE
Explain automatic version iteration

### DIFF
--- a/docs/usage/catalog.rst
+++ b/docs/usage/catalog.rst
@@ -72,11 +72,19 @@ In this case, the ``identifier`` will be the same for all of them but they will 
 
 We specified the identifier when adding the Source to the Catalog.
 However, the version was automatically set.
-We could have set the version ourselves as well:
+
+If we set another source (or the same one in this example) on the same key, a new version will automatically be created:
 
 .. code-block:: python
 
-    cat["my_source"][2] = source  # setting version 2 of the same source
+    cat["my_source"] = source  # Automatically add new version of the same source
+
+
+We could have set the version ourselves as well. So the following would have had the same effect, but in this case would explicitly overwrite the existing version:
+
+.. code-block:: python
+
+    cat["my_source"][2] = source  # Explicitly setting or overwriting version 2
 
 Now the catalog entry has become::
 

--- a/docs/usage/catalog.rst
+++ b/docs/usage/catalog.rst
@@ -73,14 +73,16 @@ In this case, the ``identifier`` will be the same for all of them but they will 
 We specified the identifier when adding the Source to the Catalog.
 However, the version was automatically set.
 
-If we set another source (or the same one in this example) on the same key, a new version will automatically be created:
+If we set another source (or the same one in this example) on the same key, 
+a new version will automatically be created:
 
 .. code-block:: python
 
     cat["my_source"] = source  # Automatically add new version of the same source
 
 
-We could have set the version ourselves as well. So the following would have had the same effect, but in this case would explicitly overwrite the existing version:
+We could have set the version ourselves as well. So the following would have had the same effect, 
+but in this case would explicitly overwrite the existing version:
 
 .. code-block:: python
 

--- a/docs/usage/catalog.rst
+++ b/docs/usage/catalog.rst
@@ -70,19 +70,17 @@ single version of a Source.
 Inside a Catalog, there can be multiple ``CatalogSource``s for a single data source.
 In this case, the ``identifier`` will be the same for all of them but they will each have a unique version number.
 
-We specified the identifier when adding the Source to the Catalog.
-However, the version was automatically set.
+We specified the identifier when adding the Source to the Catalog. However, the version was automatically set.
 
-If we set another source (or the same one in this example) on the same key, 
-a new version will automatically be created:
+If we set another source (or the same one in this example) on the same key, a new version will automatically be created:
 
 .. code-block:: python
 
     cat["my_source"] = source  # Automatically add new version of the same source
 
 
-We could have set the version ourselves as well. So the following would have had the same effect, 
-but in this case would explicitly overwrite the existing version:
+We could have set the version ourselves as well. So the following would have had the same effect, but in this
+case would explicitly overwrite the existing version:
 
 .. code-block:: python
 


### PR DESCRIPTION
# Description

Adding explanation of the default version iteration behaviour of the catalog, which was not clearly stated before.

Fixes # issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [x] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/usage/code_of_conduct.html) (external contributors only)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
