### PR TITLE
Add hooks to check backwards compatibility with py3.6+

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -25,6 +25,7 @@ ignore =
     ANN101, # Missing type annotation for self in method
     ANN102, # Missing type annotation for cls in classmethod
     ANN204, # Missing return type annotation for special method, e.g. init
+    ANN401, # Dynamically typed expressions (typing.Any) are disallowed
     # The following is for the docstring plugin, to make it less whiny. We are happy if we have docs on all functions
     D100, # Missing docstring in public module
     D101, # Missing docstring in public class

--- a/.flake8
+++ b/.flake8
@@ -39,3 +39,5 @@ max_line_length = 120
 import_order_style = appnexus
 application_package_names = devtool
 docstring-convention = google
+# 3.6.0 does not allow defaults or methods in NamedTuples, which breaks CatalogKey 
+min_python_version = 3.6.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,35 +6,36 @@ default_language_version:
   python: python3.9
 exclude: (?x)(^docs/_build)
 repos:
-- repo: https://github.com/psf/black
-  rev: 22.3.0
-  hooks:
-  - id: black # Format Python code
-    additional_dependencies: ["--index-url=https://pypi.org/simple/"]
-- repo: https://github.com/pre-commit/mirrors-autopep8
-  rev: v1.5.4  # Use the sha / tag you want to point at
-  hooks:
-  - id: autopep8
-    additional_dependencies: ["--index-url=https://pypi.org/simple/"]
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
-  hooks:
-  - id: flake8 # Apply flake 8 python file linter
-    additional_dependencies:
-    - "--index-url=https://pypi.org/simple/"
-    - "flake8-annotations==2.5.0"
-    - "flake8-bugbear==21.9.2"
-    - "flake8-docstrings==1.5.0"
-- repo: https://github.com/adrienverge/yamllint
-  rev: v1.26.1
-  hooks:
-  - id: yamllint # Check YAML Files
-    args: ['-d', "{extends: relaxed, rules: {line-length: {max: 120 }}}"]
-    additional_dependencies: ["--index-url=https://pypi.org/simple/"]
-- repo: https://github.com/PyCQA/doc8
-  rev: v1.0.0
-  hooks:
-  - id: doc8
-    args: [--max-line-length, "120"]
-    additional_dependencies: ["--index-url=https://pypi.org/simple/"]
-
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black # Format Python code
+        additional_dependencies: [--index-url=https://pypi.org/simple/]
+  - repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.5.4 # Use the sha / tag you want to point at
+    hooks:
+      - id: autopep8
+        additional_dependencies: [--index-url=https://pypi.org/simple/]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8 # Apply flake 8 python file linter
+        additional_dependencies:
+          - --index-url=https://pypi.org/simple/
+          - flake8-annotations==2.9.1
+          - flake8-bugbear==22.8.23
+          - flake8-docstrings==1.6.0
+          - flake8-walrus==1.2.0
+          - flake8-typing-imports==1.13.0
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.26.1
+    hooks:
+      - id: yamllint # Check YAML Files
+        args: [-d, '{extends: relaxed, rules: {line-length: {max: 120 }}}']
+        additional_dependencies: [--index-url=https://pypi.org/simple/]
+  - repo: https://github.com/PyCQA/doc8
+    rev: v1.0.0
+    hooks:
+      - id: doc8
+        args: [--max-line-length, '120']
+        additional_dependencies: [--index-url=https://pypi.org/simple/]

--- a/squirrel/driver/driver.py
+++ b/squirrel/driver/driver.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 __all__ = ["Driver", "IterDriver", "MapDriver", "DataFrameDriver"]
 
 
-class Driver(ABC):
+class Driver(ABC):  # noqa: B024, we want to make it explicit that this class is abstract
     """Drives the access to a data source."""
 
     name: str


### PR DESCRIPTION
# Description

Updates flake8 hook version and introduces two flake8-plugins to check for backwards-incompatible syntax.
- flake8-walrus check for the usage of the walrus operator and warns if used
- flake8-typing-imports checks for incompatible imports of the typing module

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [x] Other (please describe):

# Checklist:

- [ ] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/usage/code_of_conduct.html) (external contributors only)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
