### PR TITLE
add pypi simple as additional index to pre-commit configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,9 +57,12 @@ repos:
     rev: 1.3.2
     hooks:
       - id: poetry-check
+        additional_dependencies: [--index-url=https://pypi.org/simple/]
       - id: poetry-lock
         args: [--check]
         files: ^pyproject.toml$
+        additional_dependencies: [--index-url=https://pypi.org/simple/]
       - id: poetry-export
         args: [-f, requirements.txt, -o, requirements.txt, --with=dev, --with=doc, -Eall]
         files: ^(pyproject.toml|poetry.lock)$
+        additional_dependencies: [--index-url=https://pypi.org/simple/]


### PR DESCRIPTION
# Description

In the pre-commit configs the pypi simple index was missing for the poetry hooks. This was identified thanks to @ditschuk.

Slack conversation related to this issue:
https://merantix.slack.com/archives/C0471PCCRJN/p1680270881546339

Fixes # issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/developer/code_of_conduct.html) (external contributors only)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
