### PR TITLE
Fix composable loop reinit bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "squirrel-core"
-version = "0.19.0"
+version = "0.19.1"
 description = "Squirrel is a Python library that enables ML teams to share, load, and transform data in a collaborative, flexible and efficient way."
 authors = ["Merantix Momentum"]
 license = "Apache 2.0"

--- a/squirrel/iterstream/base.py
+++ b/squirrel/iterstream/base.py
@@ -449,7 +449,7 @@ class _LoopIterable(Composable):
                 except StopIteration:
                     if not _started:
                         return
-                current_ = iter(deepcopy(self.source))
+                    current_ = iter(deepcopy(self.source))
         else:
             for _ in range(self.n):
                 yield from iter(deepcopy(self.source))

--- a/test/test_iterstream/test_stream.py
+++ b/test/test_iterstream/test_stream.py
@@ -191,6 +191,17 @@ def test_loop(samples: t.List[SampleType], n: int) -> None:
     assert IterableSource([1, 2, 3]).loop(3).collect() == [1, 2, 3, 1, 2, 3, 1, 2, 3]
 
 
+def test_loop_infinite() -> None:
+    """Test infinite loop"""
+    it = IterableSource([1, 2, 3]).loop()
+    data = []
+    for i, x in enumerate(it):
+        data.append(x)
+        if i == 8:
+            break
+    assert data == [1, 2, 3, 1, 2, 3, 1, 2, 3]
+
+
 def test_take_side_effect() -> None:
     """Test that take_ fetches correct number of elements from an iterator."""
     lst = [1, 2, 3, 4]


### PR DESCRIPTION
# Description
Fixes a tiny but significant bug in `loop` method of `Composable` class.
Running an infinite loop previously resulted in yielding only the very first item of the IterableSource due to a reinitialization of the iterator caused by a wrong indentation level.

The fix is straightforward by correcting the indentation level of the iterator reinitialization.

A test is added to testcase the infinite-loop setting which was previously untested.

See the test or this simple snippet to showcase the bug:

```python
from squirrel.iterstream.source import IterableSource

source = IterableSource(range(3)).loop()

for i, x in enumerate(source):
    print(x)
    if i == 9:
        break
# previously yielded [0, 0, ..., 0], should yield [0, 1, 2, ..., 1, 2]
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [x] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/developer/code_of_conduct.html) (external contributors only)
- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All dependency changes have been reflected in the pip requirement files. 
