### PR TITLE
Add counter to _LoopIterable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "squirrel-core"
-version = "0.19.3"
+version = "0.19.4"
 description = "Squirrel is a Python library that enables ML teams to share, load, and transform data in a collaborative, flexible and efficient way."
 authors = ["Merantix Momentum"]
 license = "Apache 2.0"

--- a/squirrel/iterstream/base.py
+++ b/squirrel/iterstream/base.py
@@ -434,6 +434,7 @@ class _LoopIterable(Composable):
         """Init"""
         super().__init__(source=source)
         self.n = n
+        self.counter = 0
 
     def __iter__(self) -> t.Iterator:
         """Iterate over the iterable n times"""
@@ -447,9 +448,11 @@ class _LoopIterable(Composable):
                 except StopIteration:
                     if not _started:
                         return
+                    self.counter += 1
                     current_ = iter(deepcopy(self.source))
         else:
             for _ in range(self.n):
+                self.counter += 1
                 yield from iter(deepcopy(self.source))
 
 

--- a/squirrel/iterstream/base.py
+++ b/squirrel/iterstream/base.py
@@ -452,8 +452,8 @@ class _LoopIterable(Composable):
                     current_ = iter(deepcopy(self.source))
         else:
             for _ in range(self.n):
-                self.counter += 1
                 yield from iter(deepcopy(self.source))
+                self.counter += 1
 
 
 class _ZipIndexIterable(Composable):

--- a/test/test_iterstream/test_stream.py
+++ b/test/test_iterstream/test_stream.py
@@ -202,7 +202,16 @@ def test_loop_infinite() -> None:
     assert data == [1, 2, 3, 1, 2, 3, 1, 2, 3]
 
 
-def test_loop_counter() -> None:
+def test_loop_finite_counter() -> None:
+    """Test loop counter"""
+    it = IterableSource([1, 2, 3]).loop(n=3)
+    counter = []
+    for _ in it:
+        counter.append(it.counter)
+    assert counter == [0, 0, 0, 1, 1, 1, 2, 2, 2]
+
+
+def test_loop_infinite_counter() -> None:
     """Test loop counter"""
     it = IterableSource([1, 2, 3]).loop()
     counter = []

--- a/test/test_iterstream/test_stream.py
+++ b/test/test_iterstream/test_stream.py
@@ -202,6 +202,17 @@ def test_loop_infinite() -> None:
     assert data == [1, 2, 3, 1, 2, 3, 1, 2, 3]
 
 
+def test_loop_counter() -> None:
+    """Test loop counter"""
+    it = IterableSource([1, 2, 3]).loop()
+    counter = []
+    for i, _ in enumerate(it):
+        counter.append(it.counter)
+        if i == 8:
+            break
+    assert counter == [0, 0, 0, 1, 1, 1, 2, 2, 2]
+
+
 def test_take_side_effect() -> None:
     """Test that take_ fetches correct number of elements from an iterator."""
     lst = [1, 2, 3, 4]


### PR DESCRIPTION
# Description

Tiny extension to add a counter to loop iterables holding the current number of iterations of an iterable.
This can be useful to track the current state of that iterable, in particular when using it with infinite loops.
E.g. our use case is that we sample from multiple datasets that each loop indefinitely. Depending on their size, some datasets loop more often than others and it would be nice, e.g. at the end of a training, to see how many times each dataset was iterated over.