### PR TITLE
Make iterator instantiation lazy to guarantee picklability

### DIFF
--- a/test/test_iterstream/test_stream.py
+++ b/test/test_iterstream/test_stream.py
@@ -527,6 +527,20 @@ def test_iterablesamplersource_all_sampled(probs: t.Optional[t.List[float]]) -> 
     assert set(res) == set(range(7))
 
 
+@pytest.mark.parametrize("probs", [[0.4, 0.6], None])
+def test_iterablesamplersource_is_picklable(probs: t.Optional[t.List[float]]) -> None:
+    """Smoke test IterableSamplerSource"""
+    res_1 = IterableSource([0, 1, 2, 3])
+    res_2 = IterableSource([4, 5, 6])
+    src = IterableSamplerSource([res_1, res_2], probs=probs)
+    import pickle
+
+    pkl = pickle.dumps(src)
+    src_2 = pickle.loads(pkl)
+
+    assert src.collect() == src_2.collect()
+
+
 def test_filepathgenerator_nested() -> None:
     """Test FilePathGenerator with on without nested argument"""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.

Fixes [# issue](https://github.com/merantix-momentum/squirrel-core/issues/162)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [x] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/developer/code_of_conduct.html) (external contributors only)
- [x] Lint and unit tests pass locally with my changes
- [x] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
