### PR TITLE
Feat/ray dataset from get iter

### DIFF
--- a/docs/usage/architecture_overview.rst
+++ b/docs/usage/architecture_overview.rst
@@ -27,7 +27,7 @@ Here is a complete data loading pipeline:
     train_data = (
         catalog["imagenet"]  # CatalogSource
         .get_driver()  # Driver
-        .get_iter()  # Composable
+        .get_iter()  # Composable | ray.data.Dataset
         .map(lambda x: transform(x))  # Composable
         .filter(lambda x: filter_func(x))  # Composable
     )  # Composable
@@ -37,7 +37,7 @@ Here is a complete data loading pipeline:
 A :py:class:`Catalog` contains zero to many :py:class:`CatalogSource`\s, each of which may be retrieved by an
 identifier (or a tuple of an identifier and the version, see :ref:`usage/catalog:Catalog` for more details). :py:class:`CatalogSource`
 contains all necessary information to instantiate an object of type :py:class:`Driver`. :py:class:`Driver` may have
-a method :py:meth:`get_iter` which returns an object of type :py:class:`Composable`
+a method :py:meth:`get_iter` which returns an object of type :py:class:`Composable` or ray.data.Dataset
 (which belongs to :ref:`usage/iterstream:IterStream` module). `train_data` is an iterable that generates items lazily in a
 streaming way for minimal memory footprint.
 

--- a/docs/usage/driver.rst
+++ b/docs/usage/driver.rst
@@ -12,7 +12,7 @@ accessing data:
     url = "path/to/my/messagepack/dataset"
     driver = MessagepackDriver(url)  # a driver that reads messagepack-serialized data
     train_data = (
-        driver.get_iter()  # returns a Composable, i.e. an iterable with 'iterstream' powers
+        driver.get_iter()  # returns a Composable or ray.data.Dataset, i.e. an iterable with 'iterstream' powers
         .filter(lambda dct: not dct["is_bad_sample"])  # skip unwanted samples
         .async_map(augment_image)  # possible to use a thread/process pool, or run on dask
         .batched(size=100)
@@ -45,6 +45,7 @@ Let's see an IterDriver in action:
 
     from squirrel.driver import IterDriver
     from squirrel.iterstream import Composable, IterableSource
+    from ray.data import Dataset
 
 
     class MyDriver(IterDriver):
@@ -55,7 +56,7 @@ Let's see an IterDriver in action:
         def __init__(self, txt_path: str):
             self.txt_path = txt_path
 
-        def get_iter(self) -> Composable:
+        def get_iter(self) -> Composable | Dataset:
             with open(self.txt_path, "r") as f:
                 return IterableSource(line.strip() for line in f.readlines())
 

--- a/squirrel/benchmark/quantify_randomness.py
+++ b/squirrel/benchmark/quantify_randomness.py
@@ -6,6 +6,7 @@ from scipy.stats import kendalltau
 from squirrel.constants import SeedType
 from squirrel.driver import MapDriver
 from squirrel.iterstream.base import Composable
+from ray.data import Dataset
 
 
 class DummyShardedDriver(MapDriver):
@@ -27,7 +28,7 @@ class DummyShardedDriver(MapDriver):
         """Get key iterator"""
         yield from map(str, self.key_it)
 
-    def get_iter(self, flatten: bool = True, **kwargs) -> Composable:
+    def get_iter(self, flatten: bool = True, **kwargs) -> Composable | Dataset:
         """Get iterator"""
         return super().get_iter(flatten=flatten, **kwargs)
 
@@ -76,12 +77,14 @@ def quantify_randomness(
             shuffle_item_buffer=buffer_size,
             item_shuffle_kwargs={"initial": initial, "seed": seed1},
             key_shuffle_kwargs={"seed": seed1},
+            engine='iterstream',
         ).collect()
         result2 = driver.get_iter(
             shuffle_key_buffer=num_shard,
             shuffle_item_buffer=buffer_size,
             item_shuffle_kwargs={"initial": initial, "seed": seed2},
             key_shuffle_kwargs={"seed": seed2},
+            engine='iterstream',
         ).collect()
 
         # and get their distance via the kendall tau function

--- a/squirrel/driver/driver.py
+++ b/squirrel/driver/driver.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
+import ray
+from ray.data import Dataset
 import functools
 from abc import ABC, abstractmethod
-from functools import partial
-from inspect import isclass
 from typing import Any, Callable, Iterable
 
 from squirrel.catalog import Catalog
-from squirrel.iterstream import Composable, IterableSource
 
 
 __all__ = ["Driver", "IterDriver", "MapDriver"]
@@ -32,8 +31,8 @@ class IterDriver(Driver):
     """
 
     @abstractmethod
-    def get_iter(self, **kwargs) -> Composable:
-        """Returns an iterable of items in the form of a :py:class:`Composable`, which allows various stream
+    def get_iter(self, **kwargs) -> Dataset:
+        """Returns an iterable of items in the form of a :py:class:`Dataset`, which allows various stream
         manipulation functionalities.
 
         The order of the items in the iterable may or may not be randomized, depending on the implementation and
@@ -62,102 +61,15 @@ class MapDriver(IterDriver):
     def keys(self, **kwargs) -> Iterable:
         """Returns an iterable of the keys for the objects that are obtainable through the driver."""
 
-    def get_iter(
-        self,
+    def get_iter(self,
         keys_iterable: Iterable | None = None,
-        shuffle_key_buffer: int = 1,
-        key_hooks: Iterable[Callable | type[Composable] | functools.partial] | None = None,
-        max_workers: int | None = None,
-        prefetch_buffer: int = 10,
-        shuffle_item_buffer: int = 1,
-        flatten: bool = False,
         keys_kwargs: dict | None = None,
         get_kwargs: dict | None = None,
-        key_shuffle_kwargs: dict | None = None,
-        item_shuffle_kwargs: dict | None = None,
-    ) -> Composable:
-        """Returns an iterable of items in the form of a :py:class:`squirrel.iterstream.Composable`, which allows
-        various stream manipulation functionalities.
+    ) -> Dataset:
+        """Returns a Ray Dataset containing the items."""
 
-        Items are fetched using the :py:meth:`get` method. The returned :py:class:`Composable` iterates over the items
-        in the order of the keys returned by the :py:meth:`keys` method.
+        keys = self.keys(**keys_kwargs) if keys_iterable is None else keys_iterable
 
-        Args:
-            keys_iterable (Iterable, optional): If provided, only the keys in `keys_iterable` will be used to fetch
-                items. If not provided, all keys in the store are used.
-            shuffle_key_buffer (int): Size of the buffer used to shuffle keys.
-            key_hooks (Iterable[Iterable[Union[Callable, Type[Composable], functools.partial]]], optional): Hooks
-                to apply to keys before fetching the items. It is an Iterable any of these objects:
+        items = [self.get(key, **get_kwargs) for key in keys]
 
-                    1) subclass of :py:meth:`~squirrel.iterstream.Composable`: in this case, `.compose(hook, **kw)`
-                       will be applied to the stream
-                    2) A Callable:  `.to(hook, **kw)` will be applied to the stream
-                    3) A partial function: the three attributes `args`, `keywords` and `func` will be retrieved, and
-                       depending on whether `func` is a subclass of :py:meth:`~squirrel.iterstream.Composable` or a
-                       `Callable`, one of the above cases will happen, with the only difference that arguments are
-                       passed too. This is useful for passing arguments.
-            max_workers (int, optional): If `max_workers` is equal to 0 or 1,
-                :py:meth:`~squirrel.iterstream.Composable.map` is called to fetch the items iteratively.
-                If `max_workers` is bigger than 1 or equal to `None`,
-                :py:meth:`~squirrel.iterstream.Composable.async_map` is called to fetch multiple items simultaneously.
-                In this case, the `max_workers` argument refers to the maximum number of
-                workers in the :py:class:`ThreadPoolExecutor <concurrent.futures.ThreadPoolExecutor>`
-                Pool of :py:meth:`~squirrel.iterstream.Composable.async_map`.
-                `None` has a special meaning in this context and uses an internal heuristic for the number of workers.
-                The exact number of workers with `max_workers=None` depends on the specific Python version.
-                See :py:class:`ThreadPoolExecutor <concurrent.futures.ThreadPoolExecutor>` for details.
-                Defaults to None.
-            prefetch_buffer (int): Size of the buffer used for prefetching items if `async_map` is used. See
-                `max_workers` for more details. Please be aware of the memory footprint when setting this parameter.
-            shuffle_item_buffer (int): Size of the buffer used to shuffle items after being fetched. Please be aware of
-                the memory footprint when setting this parameter.
-            flatten (bool): Whether to flatten the returned iterable. Defaults to False.
-            keys_kwargs (Dict, optional): Keyword arguments passed to :py:meth:`keys` when getting the keys in the
-                store. Not used if `keys_iterable` is provided. Defaults to None.
-            get_kwargs (Dict, optional): Keyword arguments passed to :py:meth:`get` when fetching items. Defaults to
-                None.
-            key_shuffle_kwargs (Dict, optional): Keyword arguments passed to :py:meth:`shuffle` when shuffling keys.
-                Defaults to None. Can be useful to e.g. set the seed etc.
-            item_shuffle_kwargs (Dict, optional): Keyword arguments passed to :py:meth:`shuffle` when shuffling items.
-                Defaults to None. Can be useful to e.g. set the seed etc.
-
-        Returns:
-            (squirrel.iterstream.Composable) Iterable over the items in the store.
-        """
-        keys_kwargs = {} if keys_kwargs is None else keys_kwargs
-        get_kwargs = {} if get_kwargs is None else get_kwargs
-        key_shuffle_kwargs = {} if key_shuffle_kwargs is None else key_shuffle_kwargs
-        item_shuffle_kwargs = {} if item_shuffle_kwargs is None else item_shuffle_kwargs
-        keys_it = keys_iterable if keys_iterable is not None else partial(self.keys, **keys_kwargs)
-        it = IterableSource(keys_it).shuffle(size=shuffle_key_buffer, **key_shuffle_kwargs)
-
-        if key_hooks:
-            for hook in key_hooks:
-                arg = []
-                kwarg = {}
-                f = hook
-                if isinstance(hook, partial):
-                    arg = hook.args
-                    kwarg = hook.keywords
-                    f = hook.func
-
-                if isclass(f) and issubclass(f, Composable):
-                    it = it.compose(f, *arg, **kwarg)
-                elif isinstance(f, Callable):
-                    it = it.to(f, *arg, **kwarg)
-                else:
-                    raise ValueError(
-                        f"wrong argument for hook {hook}, it should be a Callable, partial function, or a subclass "
-                        f"of Composable"
-                    )
-
-        map_fn = partial(self.get, **get_kwargs)
-        _map = (
-            it.map(map_fn)
-            if max_workers is not None and max_workers <= 1
-            else it.async_map(map_fn, prefetch_buffer, max_workers)
-        )
-        if flatten:
-            _map = _map.flatten()
-
-        return _map.shuffle(size=shuffle_item_buffer, **item_shuffle_kwargs)
+        dataset = ray.data.from_items(items)

--- a/squirrel/driver/driver.py
+++ b/squirrel/driver/driver.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-import ray
-from ray.data import Dataset
 import functools
 from abc import ABC, abstractmethod
+from functools import partial
+from inspect import isclass
 from typing import Any, Callable, Iterable
+from ray.data import Dataset, from_items, range as ray_range
+from pydantic import BaseModel
 
 from squirrel.catalog import Catalog
+from squirrel.iterstream import Composable, IterableSource
 
 
 __all__ = ["Driver", "IterDriver", "MapDriver"]
@@ -31,8 +34,8 @@ class IterDriver(Driver):
     """
 
     @abstractmethod
-    def get_iter(self, **kwargs) -> Dataset:
-        """Returns an iterable of items in the form of a :py:class:`Dataset`, which allows various stream
+    def get_iter(self, **kwargs) -> Composable | Dataset:
+        """Returns an iterable of items in the form of a :py:class:`Composable`, or ray.data.Dataset which allows various stream
         manipulation functionalities.
 
         The order of the items in the iterable may or may not be randomized, depending on the implementation and
@@ -44,7 +47,7 @@ class MapDriver(IterDriver):
     """A Driver that allows retrieval of items using keys, in addition to allowing iteration over the items."""
 
     @abstractmethod
-    def get(self, key: Any, **kwargs) -> Any:
+    def get(self, key: Any, **kwargs) -> BaseModel:
         """Returns an iterable over the items corresponding to `key`.
 
         Note that it is possible to implement this method according to your needs. There is no restriction on the type
@@ -61,15 +64,146 @@ class MapDriver(IterDriver):
     def keys(self, **kwargs) -> Iterable:
         """Returns an iterable of the keys for the objects that are obtainable through the driver."""
 
-    def get_iter(self,
+    def get_iter(
+        self,
         keys_iterable: Iterable | None = None,
+        shuffle_key_buffer: int = 1,
+        key_hooks: Iterable[Callable | type[Composable] | functools.partial] | None = None,
+        max_workers: int | None = None,
+        prefetch_buffer: int = 10,
+        shuffle_item_buffer: int = 1,
+        flatten: bool = False,
         keys_kwargs: dict | None = None,
         get_kwargs: dict | None = None,
-    ) -> Dataset:
-        """Returns a Ray Dataset containing the items."""
+        key_shuffle_kwargs: dict | None = None,
+        item_shuffle_kwargs: dict | None = None,
+        engine: str = 'ray',
+    ) -> Composable | Dataset:
+        """Returns an iterable of items in the form of a :py:class:`squirrel.iterstream.Composable` or a `ray.data.Dataset`, which allows
+        various stream manipulation functionalities.
 
-        keys = self.keys(**keys_kwargs) if keys_iterable is None else keys_iterable
+        Items are fetched using the :py:meth:`get` method. The returned :py:class:`Composable` iterates over the items
+        in the order of the keys returned by the :py:meth:`keys` method.
 
-        items = [self.get(key, **get_kwargs) for key in keys]
+        Args:
+            keys_iterable (Iterable, optional): If provided, only the keys in `keys_iterable` will be used to fetch
+                items. If not provided, all keys in the store are used.
+            shuffle_key_buffer (int): Size of the buffer used to shuffle keys.
+            key_hooks (Iterable[Iterable[Union[Callable, Type[Composable], functools.partial]]], optional): Hooks
+                to apply to keys before fetching the items. It is an Iterable any of these objects:
 
-        dataset = ray.data.from_items(items)
+                    1) subclass of :py:meth:`~squirrel.iterstream.Composable`: in this case, `.compose(hook, **kw)`
+                       will be applied to the stream
+                    2) A Callable:  `.to(hook, **kw)` will be applied to the stream
+                    3) A partial function: the three attributes `args`, `keywords` and `func` will be retrieved, and
+                       depending on whether `func` is a subclass of :py:meth:`~squirrel.iterstream.Composable` or a
+                       `Callable`, one of the above cases will happen, with the only difference that arguments are
+                       passed too. This is useful for passing arguments.
+            max_workers (int, optional): If `max_workers` is equal to 0 or 1,
+                :py:meth:`~squirrel.iterstream.Composable.map` is called to fetch the items iteratively.
+                If `max_workers` is bigger than 1 or equal to `None`,
+                :py:meth:`~squirrel.iterstream.Composable.async_map` is called to fetch multiple items simultaneously.
+                In this case, the `max_workers` argument refers to the maximum number of
+                workers in the :py:class:`ThreadPoolExecutor <concurrent.futures.ThreadPoolExecutor>`
+                Pool of :py:meth:`~squirrel.iterstream.Composable.async_map`.
+                `None` has a special meaning in this context and uses an internal heuristic for the number of workers.
+                The exact number of workers with `max_workers=None` depends on the specific Python version.
+                See :py:class:`ThreadPoolExecutor <concurrent.futures.ThreadPoolExecutor>` for details.
+                Defaults to None.
+            prefetch_buffer (int): Size of the buffer used for prefetching items if `async_map` is used. See
+                `max_workers` for more details. Please be aware of the memory footprint when setting this parameter.
+            shuffle_item_buffer (int): Size of the buffer used to shuffle items after being fetched. Please be aware of
+                the memory footprint when setting this parameter.
+            flatten (bool): Whether to flatten the returned iterable. Defaults to False.
+            keys_kwargs (Dict, optional): Keyword arguments passed to :py:meth:`keys` when getting the keys in the
+                store. Not used if `keys_iterable` is provided. Defaults to None.
+            get_kwargs (Dict, optional): Keyword arguments passed to :py:meth:`get` when fetching items. Defaults to
+                None.
+            key_shuffle_kwargs (Dict, optional): Keyword arguments passed to :py:meth:`shuffle` when shuffling keys.
+                Defaults to None. Can be useful to e.g. set the seed etc.
+            item_shuffle_kwargs (Dict, optional): Keyword arguments passed to :py:meth:`shuffle` when shuffling items.
+                Defaults to None. Can be useful to e.g. set the seed etc.
+            engine (srt, optional): If engine equals 'ray', the method returns a ray.data.Dataset, if engine is 'iterstream' then return squirrel.iterstream.Composable. 
+                Otherwise, it raise an error.
+
+        Returns:
+            (squirrel.iterstream.Composable | ray.data.Dataset) Iterable over the items in the store.
+        """
+        keys_kwargs = {} if keys_kwargs is None else keys_kwargs
+        get_kwargs = {} if get_kwargs is None else get_kwargs
+        key_shuffle_kwargs = {} if key_shuffle_kwargs is None else key_shuffle_kwargs
+        item_shuffle_kwargs = {} if item_shuffle_kwargs is None else item_shuffle_kwargs
+        keys_it = keys_iterable if keys_iterable is not None else partial(self.keys, **keys_kwargs)
+
+
+        if engine == 'ray':
+            # read keys in a generator to avoid memory overflow
+            def _key_read_f(x):
+                for y in self.store.keys():
+                    yield {'item': y}
+            it = ray_range(1).flat_map(_key_read_f)
+            num_keys = it.count()
+            it = it.random_shuffle()
+
+            # parallelize reading
+            max_workers = num_keys if max_workers is None or max_workers > num_keys else max_workers
+            it = it.repartition(max_workers)
+            
+            # inject hooks
+            if key_hooks:
+                for hook in key_hooks:
+                    arg = []
+                    kwarg = {}
+                    f = hook
+                    if isinstance(hook, partial):
+                        arg = hook.args
+                        kwarg = hook.keywords
+                        f = hook.func
+                    if isinstance(f, Callable):
+                        map_fn = lambda x: {"item": f(x["item"], *arg, **kwarg)}
+                        it = it.map(map_fn)
+                    else:
+                        raise ValueError(
+                            f"wrong argument for hook {hook}, it should be a Callable or partial function"
+                        )
+
+            # read items
+            map_fn = lambda x: partial(self.store.get, **get_kwargs)(x["item"])
+            it = it.flat_map(map_fn)
+            #it = it.random_shuffle() WARNING no global shuffling. shuffling has to be done when iterating over batches
+            return it
+        elif engine == 'iterstream':
+            it = IterableSource(keys_it).shuffle(size=shuffle_key_buffer, **key_shuffle_kwargs)
+
+            if key_hooks:
+                for hook in key_hooks:
+                    arg = []
+                    kwarg = {}
+                    f = hook
+                    if isinstance(hook, partial):
+                        arg = hook.args
+                        kwarg = hook.keywords
+                        f = hook.func
+
+                    if isclass(f) and issubclass(f, Composable):
+                        it = it.compose(f, *arg, **kwarg)
+                    elif isinstance(f, Callable):
+                        it = it.to(f, *arg, **kwarg)
+                    else:
+                        raise ValueError(
+                            f"wrong argument for hook {hook}, it should be a Callable, partial function, or a subclass "
+                            f"of Composable"
+                        )
+
+            map_fn = partial(self.get, **get_kwargs)
+            _map = (
+                it.map(map_fn)
+                if max_workers is not None and max_workers <= 1
+                else it.async_map(map_fn, prefetch_buffer, max_workers)
+            )
+            if flatten:
+                _map = _map.flatten()
+
+            return _map.shuffle(size=shuffle_item_buffer, **item_shuffle_kwargs)
+        else:
+            raise ValueError("Invalid engine specified. Choose either 'ray' or 'iterstream'.")

--- a/squirrel/driver/jsonl.py
+++ b/squirrel/driver/jsonl.py
@@ -5,6 +5,7 @@ import typing as t
 from squirrel.driver.store import StoreDriver
 from squirrel.iterstream import Composable
 from squirrel.serialization import JsonSerializer
+from ray.data import Dataset
 
 __all__ = ["JsonlDriver"]
 
@@ -45,7 +46,7 @@ class JsonlDriver(StoreDriver):
         self,
         get_kwargs: t.Optional[t.Dict] = None,
         **kwargs,
-    ) -> Composable:
+    ) -> Composable | Dataset:
         """Returns an iterable of samples as specified by `fetcher_func`.
 
         Args:
@@ -54,7 +55,7 @@ class JsonlDriver(StoreDriver):
             **kwargs: Other keyword arguments that will be passed to :py:meth:`MapDriver.get_iter`.
 
         Returns:
-            (Composable) Iterable over the items in the store.
+            (Composable | ray.data.Dataset) Iterable over the items in the store.
         """
         if get_kwargs is None:
             get_kwargs = {}

--- a/squirrel/driver/source_combiner.py
+++ b/squirrel/driver/source_combiner.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
     from dask.dataframe import DataFrame
 
+    from ray.data import Dataset
     from squirrel.catalog import Catalog, CatalogKey
     from squirrel.catalog.source import Source
     from squirrel.iterstream import Composable
@@ -50,7 +51,7 @@ class SourceCombiner(MapDriver):
         key, version = self._subsets[subset]
         return self._catalog[key][version]
 
-    def get_iter(self, subset: str | None = None, **kwargs) -> Composable:
+    def get_iter(self, subset: str | None = None, **kwargs) -> Composable | Dataset:
         """Routes to the :py:meth:`get_iter` method of the appropriate subset driver.
 
         Args:
@@ -59,7 +60,7 @@ class SourceCombiner(MapDriver):
             **kwargs: Keyword arguments passed to the subset driver.
 
         Returns:
-            (Composable) Iterable over the items of subset driver(s) in the form of a :py:class:`Composable`.
+            (Composable | ray.data.Dataset) Iterable over the items of subset driver(s) in the form of a :py:class:`Composable` or ray.data.Dataset.
         """
         if subset is None:
             return IterableSource(

--- a/squirrel/driver/store.py
+++ b/squirrel/driver/store.py
@@ -7,6 +7,7 @@ from squirrel.serialization import SquirrelSerializer
 from squirrel.store import SquirrelStore
 
 if TYPE_CHECKING:
+    from ray.data import Dataset
     from squirrel.iterstream import Composable
     from squirrel.store.store import AbstractStore
 
@@ -42,8 +43,8 @@ class StoreDriver(MapDriver):
         self.storage_options = storage_options if storage_options is not None else {}
         self._store = None
 
-    def get_iter(self, flatten: bool = True, **kwargs) -> Composable:
-        """Returns an iterable of items in the form of a :py:class:`squirrel.iterstream.Composable`, which allows
+    def get_iter(self, flatten: bool = True, **kwargs) -> Composable | Dataset:
+        """Returns an iterable of items in the form of a :py:class:`squirrel.iterstream.Composable` or ray.data.Dataset, which allows
         various stream manipulation functionalities.
 
         Items are fetched using the :py:meth:`get` method. The returned :py:class:`Composable` iterates over the items
@@ -55,7 +56,7 @@ class StoreDriver(MapDriver):
                 :py:meth:`squirrel.driver.MapDriver.get_iter`.
 
         Returns:
-            (squirrel.iterstream.Composable) Iterable over the items in the store.
+            (squirrel.iterstream.Composable | ray.data.Dataset) Iterable over the items in the store.
         """
         return super().get_iter(flatten=flatten, **kwargs)
 

--- a/squirrel/driver/zarr.py
+++ b/squirrel/driver/zarr.py
@@ -6,7 +6,7 @@ from squirrel.driver.driver import MapDriver
 
 if t.TYPE_CHECKING:
     from zarr.hierarchy import Group
-
+    from ray.data import Dataset
     from squirrel.iterstream import Composable
     from squirrel.zarr.group import SquirrelGroup
 
@@ -33,7 +33,7 @@ class ZarrDriver(MapDriver):
         storage_options: t.Optional[t.Dict] = None,
         flatten: bool = True,
         **kwargs,
-    ) -> Composable:
+    ) -> Composable | Dataset:
         """Returns an iterable of samples as specified by `fetcher_func`.
 
         Args:
@@ -46,7 +46,7 @@ class ZarrDriver(MapDriver):
             **kwargs: Keyword arguments that will be passed to :py:meth:`MapDriver.get_iter`.
 
         Returns:
-            (Composable) Iterable over the items in the store.
+            (Composable | ray.data.Dataset) Iterable over the items in the store.
         """
         get_kwargs = {} if storage_options is None else storage_options
         get_kwargs["fetcher_func"] = fetcher_func

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,6 +26,7 @@ import pytest
 from pytest import FixtureRequest, TempPathFactory
 from zarr.hierarchy import Group
 
+from ray.data import Dataset
 from squirrel.catalog import Catalog, Source
 from squirrel.constants import URL
 from squirrel.driver import JsonlDriver, MessagepackDriver
@@ -130,7 +131,7 @@ def custom_jsonl_store(test_path: URL, num_samples: int) -> SquirrelStore:
 @pytest.fixture(params=["jsonl", "msgpack", "in-memory"])
 def create_all_iterable_source(
     request: FixtureRequest, dummy_msgpack_store: SquirrelStore, dummy_jsonl_store: SquirrelStore, array_shape: SHAPE
-) -> Composable:
+) -> Composable | Dataset:
     """Returns three different iterable sources in formats of `jsonl`, `msgpack` and in-memory `nd-arrays`."""
     if request.param == "msgpack":
         return MessagepackDriver(url=dummy_msgpack_store.url).get_iter()


### PR DESCRIPTION
# Description

This pull request introduces a new capability to the get_iter method by implementing support for the Ray framework. With this implementation, the method now provides flexibility in choosing between two different engines: Ray and iterstream. Users can specify the engine parameter as either 'ray' or 'iterstream' to select the desired processing framework. When 'ray' is chosen, the method returns a ray.data.Dataset, enabling parallelized processing of data items. This enhancement enhances the scalability and performance of data processing tasks, particularly when dealing with large datasets. Additionally, the implementation ensures backward compatibility by retaining support for the iterstream engine.

Changes made by @ThomasWollmann 

Fixes # issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring including code style reformatting 
- [ ] Other (please describe):

# Checklist:

- [ ] I have read the [contributing guideline doc](https://squirrel-core.readthedocs.io/en/latest/developer/code_of_conduct.html) (external contributors only)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have kept the PR small so that it can be easily reviewed  
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All dependency changes have been reflected in the pip requirement files. 
