### PR TITLE
Enable fsspec file caching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "squirrel-core"
-version = "0.20.1"
+version = "0.20.2"
 description = "Squirrel is a Python library that enables ML teams to share, load, and transform data in a collaborative, flexible and efficient way."
 authors = ["Merantix Momentum"]
 license = "Apache 2.0"

--- a/squirrel/iterstream/source.py
+++ b/squirrel/iterstream/source.py
@@ -79,7 +79,7 @@ class FilePathGenerator(Composable):
     def __iter__(self) -> t.Iterator[str]:
         """Iterator that does ls and yield filepaths under the given url"""
         self.fs = get_fs_from_url(self.url, **self.storage_options)
-        urls = self.fs.ls(self.url) if self.fs.exists(self.url) else []
+        urls = self.fs.ls(self.url, detail=False) if self.fs.exists(self.url) else []
         urls.sort()
         if self.nested:
             dirs = []


### PR DESCRIPTION
Allow utilizing filecache by passing `details=False` which prevents the caching filesystems of fsspec to return a list of dicts when calling `ls`.

Closes https://github.com/merantix-momentum/squirrel-core/issues/214